### PR TITLE
fix: Images not being shown in the object matching game

### DIFF
--- a/Frontend/src/components/GameModal.tsx
+++ b/Frontend/src/components/GameModal.tsx
@@ -72,14 +72,14 @@ const GameModal = ({ gameType, onClose }: GameModalProps) => {
     pronunciation: ["WONDERFUL", "BEAUTIFUL", "AMAZING", "FANTASTIC", "BRILLIANT"],
     confusion: ["BAD", "DAD", "BED", "DIG", "PIG"],
     memoryMatchPairs: [
-      { word: "BALL", image: "/public/ball.jpg" },
-      { word: "HAT", image: "/public/hat.jpg" },
-      { word: "CAT", image: "/public/cat.jpg" },
-      { word: "FISH", image: "/public/fish.jpg" },
-      { word: "BOOK", image: "/public/book.png" }, 
-      { word: "APPLE", image: "/public/apple.jpg" },
-      { word: "DOG", image: "/public/dog.jpg" },
-      { word: "MAN", image: "/public/man.jpg" }
+      { word: "BALL", image: "/ball.jpg" },
+      { word: "HAT", image: "/hat.jpg" },
+      { word: "CAT", image: "/cat.jpg" },
+      { word: "FISH", image: "/fish.jpg" },
+      { word: "BOOK", image: "/book.png" }, 
+      { word: "APPLE", image: "/apple.jpg" },
+      { word: "DOG", image: "/dog.jpg" },
+      { word: "MAN", image: "/man.jpg" }
     ]
   };
 


### PR DESCRIPTION
images were not shown in the object matching game, rather the alt text of the particular image was present 

## fix:
changed `image: "/public/foo.png"` to `image: "/foo.png"`